### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/ami.yml
+++ b/tasks/ami.yml
@@ -15,7 +15,8 @@
   delay: 15
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       found stopped temporary instance for AMI <b>{{ instance.ami_shortname }}</b>
@@ -48,7 +49,8 @@
          | union([_aws_ec2_ami_create]) }}
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: started creating AMI <b>{{ instance.ami_shortname }}</b>
   when: notifier_role is defined

--- a/tasks/amis_encrypted.yml
+++ b/tasks/amis_encrypted.yml
@@ -64,7 +64,8 @@
     loop_var: _aws_ec2_ami_intermediate_ami
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       began encrypting
@@ -114,7 +115,8 @@
     loop_var: _aws_ec2_ami_intermediate_ami
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       destroyed unencrypted

--- a/tasks/instances_terminate.yml
+++ b/tasks/instances_terminate.yml
@@ -24,7 +24,8 @@
     instance_ids: '{{ _aws_ec2_ami_instance_facts.instances.0.instance_id }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       terminated temporary instance for AMI <b>{{ instance.ami_shortname }}</b>

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,8 @@
     loop_var: _aws_ec2_ami_filename
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-ec2-ami</b>
@@ -113,7 +114,8 @@
   include_tasks: amis_encrypted.yml
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-ec2-ami</b>


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.