### PR TITLE
Check fact dictionary elements for presence before length

### DIFF
--- a/tasks/ami.yml
+++ b/tasks/ami.yml
@@ -10,7 +10,9 @@
     profile: '{{ aws_profile }}'
     region: '{{ aws_region }}'
   register: _aws_ec2_ami_instance_facts
-  until: _aws_ec2_ami_instance_facts.instances | length == 1
+  until: >
+    ("instances" in _aws_ec2_ami_instance_facts) and
+    (_aws_ec2_ami_instance_facts.instances | length == 1)
   retries: 720
   delay: 15
 

--- a/tasks/amis_encrypted.yml
+++ b/tasks/amis_encrypted.yml
@@ -8,7 +8,9 @@
     profile: '{{ aws_profile }}'
     region: '{{ aws_region }}'
   register: _aws_ec2_ami_amis_to_encrypt_pending
-  until: _aws_ec2_ami_amis_to_encrypt_pending.images | length == 0
+  until: >
+    ("images" in _aws_ec2_ami_amis_to_encrypt_pending) and
+    (_aws_ec2_ami_amis_to_encrypt_pending.images | length == 0)
   retries: 720
   delay: 15
 
@@ -89,7 +91,9 @@
     profile: '{{ aws_profile }}'
     region: '{{ aws_region }}'
   register: _aws_ec2_ami_encrypted_amis
-  until: _aws_ec2_ami_encrypted_amis.images | length == 1
+  until: >
+    ("images" in _aws_ec2_ami_encrypted_amis) and
+    (_aws_ec2_ami_encrypted_amis.images | length == 1)
   retries: 720
   delay: 15
   with_items: '{{ _aws_ec2_ami_copy.results }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,7 +91,9 @@
     profile: '{{ aws_profile }}'
     region: '{{ aws_region }}'
   register: _aws_ec2_ami_unencrypted_amis_available
-  until: _aws_ec2_ami_unencrypted_amis_available.images | length == 1
+  until: >
+    "images" in _aws_ec2_ami_unencrypted_amis_available and
+    _aws_ec2_ami_unencrypted_amis_available.images | length == 1
   retries: 720
   delay: 15
   with_items: '{{ _aws_ec2_ami_unencrypted_amis }}'


### PR DESCRIPTION
This makes the looping checks for instances or AMIs in a certain status more robust against transient failures.